### PR TITLE
fix argument order for gpg conversion

### DIFF
--- a/tasks/install_gpg_keys.yml
+++ b/tasks/install_gpg_keys.yml
@@ -8,8 +8,7 @@
 
 - name: Convert ASCII key to binary .gpg format
   ansible.builtin.command: >
-    gpg --dearmor /etc/apt/trusted.gpg.d/{{ item.name }}.asc
-    --output /etc/apt/trusted.gpg.d/{{ item.name }}.gpg
+    gpg --dearmor --output /etc/apt/trusted.gpg.d/{{ item.name }}.gpg /etc/apt/trusted.gpg.d/{{ item.name }}.asc 
   args:
     creates: "/etc/apt/trusted.gpg.d/{{ item.name }}.gpg"
   loop: "{{ mysql_gpg_keys }}"


### PR DESCRIPTION
While running the current version I was getting

```
failed: [db-a] (item={'name': 'mysql-2023', 'url': 'https://repo.mysql.com/RPM-GPG-KEY-mysql-2023'}) => {"ansible_loop_var": "item", "changed": true, "cmd": ["gpg", "--dearmor", "/etc/apt/trusted.gpg.d/mysql-2023.asc", "--output", "/etc/apt/trusted.gpg.d/mysql-2023.gpg"], "delta": "0:00:00.008785", "end": "2025-08-31 02:37:55.097924", "item": {"name": "mysql-2023", "url": "https://repo.mysql.com/RPM-GPG-KEY-mysql-2023"}, "msg": "non-zero return code", "rc": 2, "start": "2025-08-31 02:37:55.089139", "stderr": "gpg: Note: '--output' is not considered an option\nusage: gpg [options] --dearmor [file]", "stderr_lines": ["gpg: Note: '--output' is not considered an option", "usage: gpg [options] --dearmor [file]"], "stdout": "", "stdout_lines": []} 
```

Basically the command had the wrong order of arguments. Modifying locally to the proposed version works.